### PR TITLE
Get test green.

### DIFF
--- a/src/views/OnlineLeaguePlayerLanding/OnlineLeaguePlayerLanding.test.tsx
+++ b/src/views/OnlineLeaguePlayerLanding/OnlineLeaguePlayerLanding.test.tsx
@@ -48,6 +48,9 @@ describe("COOL Player landing tests", () => {
     test("logged out player arrival", async () => {
         jest.spyOn(ogs_hooks, "useUser").mockReturnValue({ ...TEST_USER, anonymous: true });
 
+        location.pathname = "/online-league/league-player";
+        location.search = "?side=black&id=blackmatchid";
+
         //let res: ReturnType<typeof render>;
         await act(async () => {
             render(
@@ -72,6 +75,6 @@ describe("COOL Player landing tests", () => {
             );
         });
 
-        expect(screen.getByText("Welcome to OGS")).toBeDefined();
+        expect(screen.getByText("Welcome to OGS", { exact: false })).toBeDefined();
     });
 });


### PR DESCRIPTION
These are the minimal changes to get this COOL test green. You don't have to merge this, but I wanted to send over full working test.

## Proposed Changes

  - set location.search
  - Allow fuzzy matching in expectation, so lack of "!" doesn't mean a broken test.

## Alternative

The other option is to use `useLocation` in the actual code.  React hooks seem like a generally good idea, but I can't think of a concrete case where this makes a difference.
